### PR TITLE
azfile: switch to x/sys due to deprecation of syscall

### DIFF
--- a/2017-07-29/azfile/zc_mmf_unix.go
+++ b/2017-07-29/azfile/zc_mmf_unix.go
@@ -4,22 +4,23 @@ package azfile
 
 import (
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 type mmf []byte
 
 func newMMF(file *os.File, writable bool, offset int64, length int) (mmf, error) {
-	prot, flags := syscall.PROT_READ, syscall.MAP_SHARED // Assume read-only
+	prot, flags := unix.PROT_READ, unix.MAP_SHARED // Assume read-only
 	if writable {
-		prot, flags = syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED
+		prot, flags = unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED
 	}
-	addr, err := syscall.Mmap(int(file.Fd()), offset, length, prot, flags)
+	addr, err := unix.Mmap(int(file.Fd()), offset, length, prot, flags)
 	return mmf(addr), err
 }
 
 func (m *mmf) unmap() {
-	err := syscall.Munmap(*m)
+	err := unix.Munmap(*m)
 	*m = nil
 	if err != nil {
 		panic(err)

--- a/2017-07-29/azfile/zc_mmf_windows.go
+++ b/2017-07-29/azfile/zc_mmf_windows.go
@@ -3,24 +3,25 @@ package azfile
 import (
 	"os"
 	"reflect"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 type mmf []byte
 
 func newMMF(file *os.File, writable bool, offset int64, length int) (mmf, error) {
-	prot, access := uint32(syscall.PAGE_READONLY), uint32(syscall.FILE_MAP_READ) // Assume read-only
+	prot, access := uint32(windows.PAGE_READONLY), uint32(windows.FILE_MAP_READ) // Assume read-only
 	if writable {
-		prot, access = uint32(syscall.PAGE_READWRITE), uint32(syscall.FILE_MAP_WRITE)
+		prot, access = uint32(windows.PAGE_READWRITE), uint32(windows.FILE_MAP_WRITE)
 	}
 	maxSize := int64(offset + int64(length))
-	hMMF, errno := syscall.CreateFileMapping(syscall.Handle(file.Fd()), nil, prot, uint32(maxSize>>32), uint32(maxSize&0xffffffff), nil)
+	hMMF, errno := windows.CreateFileMapping(windows.Handle(file.Fd()), nil, prot, uint32(maxSize>>32), uint32(maxSize&0xffffffff), nil)
 	if hMMF == 0 {
 		return nil, os.NewSyscallError("CreateFileMapping", errno)
 	}
-	defer syscall.CloseHandle(hMMF)
-	addr, errno := syscall.MapViewOfFile(hMMF, access, uint32(offset>>32), uint32(offset&0xffffffff), uintptr(length))
+	defer windows.CloseHandle(hMMF)
+	addr, errno := windows.MapViewOfFile(hMMF, access, uint32(offset>>32), uint32(offset&0xffffffff), uintptr(length))
 	m := mmf{}
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&m))
 	h.Data = addr
@@ -32,7 +33,7 @@ func newMMF(file *os.File, writable bool, offset int64, length int) (mmf, error)
 func (m *mmf) unmap() {
 	addr := uintptr(unsafe.Pointer(&(([]byte)(*m)[0])))
 	*m = mmf{}
-	err := syscall.UnmapViewOfFile(addr)
+	err := windows.UnmapViewOfFile(addr)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Per the documentation in syscall https://golang.org/pkg/syscall/:

 > Deprecated: this package is locked down. Callers should use the corresponding package in the golang.org/x/sys repository instead. That is also where updates required by new systems or versions should be applied. See https://golang.org/s/go1.4-syscall for more information.