### PR TITLE
Store ShareUsageBytes value in int64

### DIFF
--- a/azfile/zt_examples_test.go
+++ b/azfile/zt_examples_test.go
@@ -496,7 +496,7 @@ func ExampleShareURL_SetQuota() {
 	// Check current usage stats for the share.
 	// Note that the ShareStats object is part of the protocol layer for the File service.
 	if statistics, err := shareURL.GetStatistics(ctx); err == nil {
-		shareUsageGB := statistics.ShareUsageBytes/1024/1024/1024
+		shareUsageGB := int32(statistics.ShareUsageBytes/1024/1024/1024)
 		fmt.Printf("Current share usage: %d GB\n", shareUsageGB)
 
 		shareURL.SetQuota(ctx, 10+shareUsageGB)

--- a/azfile/zt_url_share_test.go
+++ b/azfile/zt_url_share_test.go
@@ -594,7 +594,7 @@ func (s *ShareURLSuite) TestShareGetStats(c *chk.C) {
 	// c.Assert(gResp.LastModified().IsZero(), chk.Equals, false) // TODO: Even share is once updated, no LastModified would be returned.
 	c.Assert(gResp.RequestID(), chk.Not(chk.Equals), "")
 	c.Assert(gResp.Version(), chk.Not(chk.Equals), "")
-	c.Assert(gResp.ShareUsageBytes, chk.Equals, int32(0))
+	c.Assert(gResp.ShareUsageBytes, chk.Equals, int64(0))
 }
 
 func (s *ShareURLSuite) TestShareGetStatsNegative(c *chk.C) {

--- a/azfile/zz_generated_models.go
+++ b/azfile/zz_generated_models.go
@@ -2955,7 +2955,7 @@ func (ssqr ShareSetQuotaResponse) Version() string {
 type ShareStats struct {
 	rawResponse *http.Response
 	// ShareUsageBytes - The approximate size of the data stored in bytes. Note that this value may not include all recently created or recently resized files.
-	ShareUsageBytes int32 `xml:"ShareUsageBytes"`
+	ShareUsageBytes int64 `xml:"ShareUsageBytes"`
 }
 
 // Response returns the raw HTTP response object.

--- a/azfile/zz_generated_models.go
+++ b/azfile/zz_generated_models.go
@@ -2955,7 +2955,7 @@ func (ssqr ShareSetQuotaResponse) Version() string {
 type ShareStats struct {
 	rawResponse *http.Response
 	// ShareUsageBytes - The approximate size of the data stored in bytes. Note that this value may not include all recently created or recently resized files.
-	ShareUsageBytes int64 `xml:"ShareUsageBytes"`
+	ShareUsageBytes int32 `xml:"ShareUsageBytes"`
 }
 
 // Response returns the raw HTTP response object.


### PR DESCRIPTION
Type int32 is highly insufficient to store the share size in bytes. Changing to int64.